### PR TITLE
Include macros from reacl-c.dom

### DIFF
--- a/src/reacl_c_basics/forms.cljs
+++ b/src/reacl_c_basics/forms.cljs
@@ -1,6 +1,6 @@
 (ns reacl-c-basics.forms
   (:require [reacl-c.core :as c :include-macros true]
-            [reacl-c.dom :as dom]
+            [reacl-c.dom :as dom :include-macros true]
             [active.clojure.functions :as f]
             [reacl-c-basics.core :as core :include-macros true]))
 


### PR DESCRIPTION
I got weird errors when trying this out on one machine, pointing to [the first usage of `defn-dom` in `forms.cljs`](https://github.com/active-group/reacl-c-basics/blob/master/src/reacl_c_basics/forms.cljs#L10). Adding this line fixed it, though I could not reproduce the problem reliably afterwards.